### PR TITLE
Update to the Date compare in the exif data test

### DIFF
--- a/test/decoder.js
+++ b/test/decoder.js
@@ -105,7 +105,7 @@ describe('JPEGDecoder', function() {
       .on('meta', function(meta) {
         assert.equal(typeof meta, 'object');
         assert.equal(meta.image.Make, 'Canon');
-        assert.deepEqual(meta.exif.DateTimeOriginal, new Date("2004-06-17T13:47:02.000Z"));
+        assert.deepEqual(meta.exif.DateTimeOriginal.toGMTString(), new Date("2004-06-17T06:47:02.000Z").toGMTString());
         metaEmitted = true;
       })
       .pipe(concat(function(frames) {


### PR DESCRIPTION
I was encountering a failure on the exif data test on my Mac and Debian installs of the package. Changing to have both the original and the comparison on GMT solves the issue of running on PDT. Tested on node 4.1.1, 4.2.3, and 6.9.4 on Mac OSX 10.12.2, and Debian Wheezy amd64 running on a AWS EC2 hvm, with node 4.7.2.